### PR TITLE
Simple implementation of mute and unmute

### DIFF
--- a/gui/list.go
+++ b/gui/list.go
@@ -70,6 +70,13 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch msg.String() {
 		case "ctrl+c":
 			return m, tea.Quit
+		case "m":
+			m.mpv.ToggleMute()
+			mutemsg := "unmuted"
+			if m.mpv.IsMute() {
+				mutemsg = "muted"
+			}
+			return m, m.list.NewStatusMessage(mutemsg)
 		case "enter":
 			if m.playingItemIndex == m.list.Index() {
 				break

--- a/gui/list.go
+++ b/gui/list.go
@@ -141,6 +141,7 @@ func Render(ins *dbus.Instance, mpv *player.MPV, lastRadioIndex int) int {
 		return []key.Binding{
 			key.NewBinding(key.WithKeys("+"), key.WithHelp("+", "volume up")),
 			key.NewBinding(key.WithKeys("-"), key.WithHelp("-", "volume down")),
+			key.NewBinding(key.WithKeys("m"), key.WithHelp("m", "toggle mute")),
 		}
 	}
 

--- a/player/mpv.go
+++ b/player/mpv.go
@@ -26,6 +26,7 @@ type MPV struct {
 	running      bool
 	runningMutex sync.Mutex
 	mainloopExit chan struct{}
+	mute         bool
 }
 
 type State int
@@ -50,7 +51,7 @@ func (mpv *MPV) Initialize() {
 
 	mpv.mainloopExit = make(chan struct{})
 	mpv.running = true
-
+	mpv.mute = false
 	mpv.handle = C.mpv_create()
 
 	mpv.setOptionFlag("resume-playback", false)
@@ -174,6 +175,18 @@ func (mpv *MPV) SetVolume(volume float64) {
 func (mpv *MPV) Pause() {
 	mpv.setProperty("pause", "yes")
 }
+
+func (mpv *MPV) ToggleMute() {
+	mpv.mute = !mpv.mute
+	mute := "no"
+	if mpv.mute {
+		mute = "yes"
+	}
+	mpv.setProperty("mute", mute)
+}
+
+// IsMute return true if mpv is muted
+func (mpv *MPV) IsMute() bool { return mpv.mute }
 
 func (mpv *MPV) Resume() {
 	mpv.setProperty("pause", "no")


### PR DESCRIPTION
Add a simple shortcut to mute and unmute the player using the "m" key (similar to mpv)